### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @aquarela/time-to-cron
 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/13aba93ef2784b3288a28561bce307da)](https://app.codacy.com/gh/aquarela-io/time-to-cron/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+
 `@aquarela/time-to-cron` is a utility library designed to convert time intervals into cron expressions. This package is particularly useful for developers looking to schedule tasks in environments that require cron syntax, providing a simple interface to generate accurate cron schedules.
 
 ## Table of Contents

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -50,7 +50,7 @@ describe("@aquarela/timeToCron", () => {
   });
 
   test("throws error for invalid time unit", () => {
-    // @ts-ignore
+    // @ts-expect-error
     expect(() => timeToCron(1, "invalid")).toThrow("Invalid time unit");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@
  *                         For "minutes", values must be less than 60 or multiples of 60.
  *                         For "hours", values must be less than 24 or multiples of 24.
  * @param {TimeUnit} [unit="seconds"] - The unit of the time value. Can be "seconds", "minutes", "hours", or "days".
- * @param {boolean} [repeatSameDay=true] - Whether to repeat the cron job on the same day when the interval is greater than or equal to one day.
  * @returns {string} The corresponding cron expression.
  * @throws {Error} If the value is not a positive integer, if the value does not meet the unit constraints, or if an invalid time unit is provided.
  *
@@ -40,7 +39,6 @@ type TimeUnit = "seconds" | "minutes" | "hours" | "days";
 export function timeToCron(
   value: number,
   unit: TimeUnit = "seconds",
-  repeatSameDay: boolean = true
 ): string {
   if (value <= 0 || !Number.isInteger(value)) {
     throw new Error("Value must be a positive integer");


### PR DESCRIPTION
This pull request includes several changes to the `@aquarela/time-to-cron` project, focusing on documentation improvements, test updates, and code simplification.

### Documentation Improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R4): Added a Codacy badge to the readme file to display the project's code quality grade.

### Test Updates:
* [`src/index.test.ts`](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3L53-R53): Replaced `@ts-ignore` with `@ts-expect-error` in the test case for invalid time unit to make the intention of the test clearer.

### Code Simplification:
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L9): Removed the `repeatSameDay` parameter from the `timeToCron` function as it was not being used. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L9) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L43)