### PR TITLE
fix: :bug: semantic release versioning

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,10 +1,30 @@
 {
   "branches": ["main"],
+  "tagFormat": "v${version}",
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "docs", "release": "patch" },
+          { "type": "style", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "test", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
-    "@semantic-release/npm",
+    [
+      "@semantic-release/npm",
+      {
+        "pkgRoot": "."
+      }
+    ],
     [
       "@semantic-release/git",
       {


### PR DESCRIPTION
This pull request includes changes to the `.releaserc.json` file to enhance the release process by configuring semantic release plugins and specifying release rules based on commit types.

Enhancements to release process:

* Added `tagFormat` to define the version tag format as `v${version}`.
* Configured the `@semantic-release/commit-analyzer` plugin with the `angular` preset and specified release rules for various commit types such as `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, and `test`.
* Configured the `@semantic-release/npm` plugin with `pkgRoot` set to the current directory.